### PR TITLE
Add Android framework plugin gradle with dependencies

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -12,12 +12,12 @@
         </config-file>
         <header-file src="src/ios/JumioMobileSDK.h" />
         <source-file src="src/ios/JumioMobileSDK.m" />
-        
+
         <preference name="CAMERA_USAGE_DESCRIPTION" default="This will allow ${PRODUCT_NAME} to take photos of your credentials."/>
         <config-file target="*-Info.plist" parent="NSCameraUsageDescription">
             <string>$CAMERA_USAGE_DESCRIPTION</string>
         </config-file>
-        
+
         <podspec>
             <config>
                 <source url="https://github.com/CocoaPods/Specs.git"/>
@@ -27,7 +27,7 @@
             </pods>
         </podspec>
     </platform>
-    
+
     <platform name="android">
         <config-file target="AndroidManifest.xml" parent="/*">
             <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
@@ -88,6 +88,7 @@
 			-dontwarn com.microblink.**
 			-dontwarn javax.annotation.Nullable
         </proguard-config>
+        <framework src="src/android/plugin.gradle" custom="true" type="gradleReference"/>
         <source-file src="src/android/JumioMobileSDK.java" target-dir="src/com/jumio/mobilesdk" />
     </platform>
 </plugin>

--- a/src/android/plugin.gradle
+++ b/src/android/plugin.gradle
@@ -1,0 +1,51 @@
+repositories {
+	google()
+	jcenter()
+	maven { url 'https://mobile-sdk.jumio.com' }
+}
+
+ext {
+	SDK_VERSION = "3.6.0"
+	kotlin_version = "1.3.72"
+}
+
+dependencies {
+	implementation "com.jumio.android:core:${SDK_VERSION}@aar"
+	implementation "com.jumio.android:bam:${SDK_VERSION}@aar"
+	implementation "com.jumio.android:auth:${SDK_VERSION}@aar"
+	implementation "com.jumio.android:nv:${SDK_VERSION}@aar"
+	implementation "com.jumio.android:nv-mrz:${SDK_VERSION}@aar"
+	implementation "com.jumio.android:nv-nfc:${SDK_VERSION}@aar"
+	implementation "com.jumio.android:nv-ocr:${SDK_VERSION}@aar"
+	implementation "com.jumio.android:nv-barcode:${SDK_VERSION}@aar"
+	implementation "com.jumio.android:nv-barcode-vision:${SDK_VERSION}@aar"
+	implementation "com.jumio.android:face:${SDK_VERSION}@aar"
+	implementation "com.jumio.android:dv:${SDK_VERSION}@aar"
+
+	//for core:
+	implementation "androidx.appcompat:appcompat:1.1.0"
+	implementation "androidx.room:room-runtime:2.2.3"
+	implementation "androidx.localbroadcastmanager:localbroadcastmanager:1.0.0"
+
+	//for nv:
+	implementation "com.google.android.material:material:1.1.0"
+	implementation "androidx.cardview:cardview:1.0.0"
+	implementation "androidx.constraintlayout:constraintlayout:1.1.3"
+
+	//only for nv-barcode-vision
+	implementation ("com.google.android.gms:play-services-vision:19.0.0"){
+		exclude group: 'com.android.support', module:'support-v4'
+	}
+
+	//only for nv-nfc
+	implementation "org.jmrtd:jmrtd:0.7.18"
+	implementation "org.ejbca.cvc:cert-cvc:1.4.6"
+	implementation "org.bouncycastle:bcprov-jdk15on:1.64"
+	implementation "net.sf.scuba:scuba-sc-android:0.0.18"
+
+	//only for face
+	implementation "com.facetec:zoom-authentication:8.0.11@aar"
+
+	//Kotlin
+	implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
+}


### PR DESCRIPTION
I spent much time debugging how to use your Cordova plugin for Android because you did not include gradle dependencies. Here is a fix that should solve this problem for others going forward.